### PR TITLE
Update script to remove failing command

### DIFF
--- a/ODBC install scripts/installodbc_redhat.sh
+++ b/ODBC install scripts/installodbc_redhat.sh
@@ -53,7 +53,6 @@ sudo ln -s libodbc.so.2     libodbc.so.1
 
 cd /tmp/msodbcrhel/
 
-cd usr/lib64
 if sudo wget https://download.microsoft.com/download/B/C/D/BCDD264C-7517-4B7D-8159-C99FC5535680/msodbcsql-13.0.0.0.tar.gz ; 
 then 
 	echo "Successfuly download the ODBC Driver and tools." 


### PR DESCRIPTION
cd usr/lib64 does nothing and appears to be extraneous, so I have removed it entirely. At this point in the script we have already cd'ed into the required directory. This should address issue 132.